### PR TITLE
Match func_8004A2B4 controller input handler

### DIFF
--- a/include/variables.h
+++ b/include/variables.h
@@ -306,6 +306,7 @@ extern u8 D_801C43F8;
 extern s32 D_80154330;
 extern s32 D_801CB410;
 extern u8 D_80154340;
+extern OSMesg D_80154348;
 extern s32 D_801CB404;
 extern u8 D_801542E2[][4];
 extern u8 D_801CB408[];

--- a/src/game/code_23E0.c
+++ b/src/game/code_23E0.c
@@ -691,7 +691,36 @@ void func_80049710(Mtx* arg0, MtxF* arg1, f32 arg2, f32 arg3, f32 arg4, f32 arg5
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game/code_23E0/func_8004A208.s")
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game/code_23E0/func_8004A2B4.s")
+void func_8004A2B4(void) {
+    s32 i;
+    u8 mask = 1;
+
+    osRecvMesg(&D_801540D0, &D_80154348, 1);
+    osContGetReadData(gControllers);
+
+    for (i = 0; i < 4; i++) {
+        if (D_80154340 & mask) {
+            struct Controller_info* ctrl;
+            OSContPad* new_var3;
+            unsigned short new_var;
+            int new_var2;
+            
+            ctrl = &gControllerOne[i];
+            new_var3 = &gControllers[i];
+            
+            ctrl->unk6 = ctrl->unk0;
+            ctrl->unk0 = new_var3->button;
+            new_var = ctrl->unk0 ^ ctrl->unk6;
+            new_var2 = new_var;
+            ctrl->unk2 = ctrl->unk0 & new_var2;
+            ctrl->unk4 = ctrl->unk6 & new_var;
+            new_var2 = new_var & 0xFFFF;
+            ctrl->unk8 = new_var3->stick_x;
+            ctrl->unk9 = new_var3->stick_y;
+        }
+        mask <<= 1;
+    }
+}
 
 void func_8004A394(void) {
     osContStartReadData(&D_801540D0);


### PR DESCRIPTION
Implements perfect assembly matching (score 0) for func_8004A2B4 using strategic variable ordering and register allocation hints.

- Added D_80154348 declaration to variables.h
- Implemented controller input processing with bit manipulation
- Uses Controller_info struct for button state tracking
- Applied IDO 5.3 compiler optimization patterns

🤖 Generated with [Claude Code](https://claude.ai/code)